### PR TITLE
add Zenoh to jazzy

### DIFF
--- a/.github/workflows/docker-buildx-bake-build.yml
+++ b/.github/workflows/docker-buildx-bake-build.yml
@@ -1,6 +1,7 @@
 name: Docker Compose Build
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:

--- a/.github/workflows/docker-buildx-bake-build.yml
+++ b/.github/workflows/docker-buildx-bake-build.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - main  # Change this to your main branch name
       - orbbec
+      - jazzy
 
 jobs:
   build:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,6 +57,7 @@ RUN source /opt/ros/${ROS_DISTRO}/setup.bash \
 # Use Cyclone DDS as middleware and install xacro
 RUN apt-get install -y --no-install-recommends \
   ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
+  ros-${ROS_DISTRO}-rmw-zenoh-cpp \
   ros-${ROS_DISTRO}-xacro \
   && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile.zenoh
+++ b/docker/Dockerfile.zenoh
@@ -65,6 +65,7 @@ RUN source /opt/ros/${ROS_DISTRO}/setup.bash \
 # Use Cyclone DDS as middleware and install xacro
 RUN apt-get install -y --no-install-recommends \
   ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
+  ros-${ROS_DISTRO}-rmw-zenoh-cpp \
   ros-${ROS_DISTRO}-xacro \
   && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile.zenoh
+++ b/docker/Dockerfile.zenoh
@@ -29,8 +29,7 @@ RUN echo "update base 26.09.2023 - test"
 
 RUN mkdir -p /rmp_ws/src
 WORKDIR /rmp_ws/src
-COPY dependencies.arm64.repos .
-COPY dependencies.amd64.repos .
+COPY dependencies.*.repos .
 
 # Choose correct sources for architecture:
 # Copy platform-specific files
@@ -49,8 +48,8 @@ RUN if [ "$(uname -m)" = "x86_64" ]; then \
   mv dependencies.arm64.repos dependencies.repos; \
   fi
 
-#RUN vcs import < dependencies.repos
-RUN vcs import < dependencies.repos
+RUN vcs import --input dependencies.common.repos
+RUN vcs import --input dependencies.repos
 
 # Build the base Colcon workspace, installing dependencies first.
 WORKDIR /rmp_ws


### PR DESCRIPTION
I am trying to add the Zenoh RMW (`ros-${ROS_DISTRO}-rmw-zenoh-cpp`) to the already existing Docker image, in order to change the RMW at runtime via the environment variables set in the compose file. This is all a bit confusing since we have multiple branches, Dockerfiles and compose files.

Which is the branch that should be used for the most up-to-date software stack for the robot? Could we please merge all the Dockerfiles and branches together, and have the build for different distributions (`humble`, `jazzy`, ...) and RMWs (`rmw_cyclonedds_cpp`, `rmw_zenoh_cpp`, ...) configurable via scripts and the compose files?