### PR TITLE
update repo URLs

### DIFF
--- a/dependencies.amd64.repos
+++ b/dependencies.amd64.repos
@@ -1,8 +1,0 @@
-repositories:
-
-  # CPS RMP lite 220 Dependencies
-
-  segwayrmp:
-    type: git
-    url: https://github.com/mul-cps/segwayrmp.git
-    version: humble

--- a/dependencies.arm64.repos
+++ b/dependencies.arm64.repos
@@ -1,8 +1,0 @@
-repositories:
-
-  # CPS RMP lite 220 Dependencies
-
-  segwayrmp:
-    type: git
-    url: https://github.com/mul-cps/segwayrmp.git
-    version: humble-arm64

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -4,7 +4,12 @@ repositories:
 
   segway_msgs:
     type: git
-    url: https://github.com/mul-cps/segway_msgs.git
+    url: https://github.com/LuckierDodge/segway_msgs.git
+    version: main
+
+  segwayrmp:
+    type: git
+    url: https://github.com/LuckierDodge/segwayrmp.git
     version: main
 
   RPlidar_ROS2:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN echo "update base 26.09.2023 - test"
 
 RUN mkdir -p /rmp_ws/src
 WORKDIR /rmp_ws/src
-COPY dependencies.*.repos .
+COPY dependencies.repos .
 
 # Choose correct sources for architecture:
 # Copy platform-specific files
@@ -32,15 +32,6 @@ RUN uname -a
 
 RUN echo "update base 29.08.2023"
 
-RUN if [ "$(uname -m)" = "x86_64" ]; then \
-  echo "Copying files for linux/amd64"; \
-  mv dependencies.amd64.repos dependencies.repos; \
-  else \
-  echo "Copying files for linux/arm64"; \
-  mv dependencies.arm64.repos dependencies.repos; \
-  fi
-
-RUN vcs import --input dependencies.common.repos
 RUN vcs import --input dependencies.repos
 
 # Build the base Colcon workspace, installing dependencies first.

--- a/docker/Dockerfile.zenoh
+++ b/docker/Dockerfile.zenoh
@@ -29,7 +29,7 @@ RUN echo "update base 26.09.2023 - test"
 
 RUN mkdir -p /rmp_ws/src
 WORKDIR /rmp_ws/src
-COPY dependencies.*.repos .
+COPY dependencies.repos .
 
 # Choose correct sources for architecture:
 # Copy platform-specific files
@@ -40,15 +40,6 @@ RUN uname -a
 
 RUN echo "update base 29.08.2023"
 
-RUN if [ "$(uname -m)" = "x86_64" ]; then \
-  echo "Copying files for linux/amd64"; \
-  mv dependencies.amd64.repos dependencies.repos; \
-  else \
-  echo "Copying files for linux/arm64"; \
-  mv dependencies.arm64.repos dependencies.repos; \
-  fi
-
-RUN vcs import --input dependencies.common.repos
 RUN vcs import --input dependencies.repos
 
 # Build the base Colcon workspace, installing dependencies first.


### PR DESCRIPTION
A search for [`mul-cps/segwayrmp`](https://github.com/search?q=org%3Amul-cps+mul-cps%2Fsegwayrmp&type=code) and [`mul-cps/segway_msgs`](https://github.com/search?q=org%3Amul-cps%20mul-cps%2Fsegway_msgs&type=code) shows that the old URLs are not used anywhere else. That means we should be fine removing the old repos once this has been merged. I guess.